### PR TITLE
Fix for Bungee servers

### DIFF
--- a/java/com/mumfrey/worldeditcui/LiteModWorldEditCUI.java
+++ b/java/com/mumfrey/worldeditcui/LiteModWorldEditCUI.java
@@ -131,7 +131,7 @@ public class LiteModWorldEditCUI implements InitCompleteListener, PluginChannelL
 				this.controller.getDebugger().debug("World change detected, sending new handshake");
 				this.controller.setSelection(new CuboidRegion(this.controller));
 				this.helo();
-				mc.thePlayer.sendChatMessage("/we cui"); //Tricks WE to send the current selection	
+				if (mc.thePlayer != null) mc.thePlayer.sendChatMessage("/we cui"); //Tricks WE to send the current selection	
 			}
 		}
 	}


### PR DESCRIPTION
Always sends a new handshake packet when the world changes (to detect that the player switched the server). Also clears the selection because it is bound to a world and shouldn't be kept on another world.
Because the server doesn't send the current selection when joining the game or receiving a handshake, we need to trick it with "/we cui" to send the selection.
