### PR TITLE
Fixed using wrong color for second corner in CuboidRegion

### DIFF
--- a/java/com/mumfrey/worldeditcui/render/region/CuboidRegion.java
+++ b/java/com/mumfrey/worldeditcui/render/region/CuboidRegion.java
@@ -72,7 +72,7 @@ public class CuboidRegion extends Region
 	{
 		if (id < 2)
 		{
-			this.points[id] = new PointCube(x, y, z).setStyle(this.styles[2]);
+			this.points[id] = new PointCube(x, y, z).setStyle(this.styles[id+2]);
 		}
 		
 		this.updateBounds();
@@ -83,7 +83,7 @@ public class CuboidRegion extends Region
 	{
 		if (id < 2)
 		{
-			this.points[id] = new PointCubeTracking(entity, traceDistance).setStyle(this.styles[2]);
+			this.points[id] = new PointCubeTracking(entity, traceDistance).setStyle(this.styles[id+2]);
 		}
 		
 		this.updateBounds();


### PR DESCRIPTION
Both corners in a cuboid region are using the same color, which is the first corner color.
Neither the client settings, not the multi-packets can change the second color. (I need that feature though)

> I couldn't test the changes, sadly. 
>  Since it was impossible for me to get liteloader with gradle compiled. Sorry.